### PR TITLE
Fix discovered artifact paths on Windows

### DIFF
--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -46,7 +46,7 @@ class Gem::Compiler
     # add discovered artifacts
     artifacts.each do |path|
       # path needs to be relative to target_dir
-      file = path.gsub("#{target_dir}/", "")
+      file = path.gsub("#{File.join(Dir.glob(target_dir), '')}", "")
 
       debug "Adding '#{file}' to gemspec"
       gemspec.files.push file


### PR DESCRIPTION
Gem::Compiler::compile computes `target_dir` via Dir.mktmpdir, which returns a path containing components such as `C:/Users/MIKEBL~1` to represent path components containg spaces such as  `C:/Users/Mike Bland`.

The `artifacts` in Gem::Compiler::compile are computed using Dir.glob, which will expand path `C:/Users/MIKEBL~1` to `C:/Users/Mike Bland`.

Consequently, passing `target_dir` to `path.gsub` results in the `path` remaining the same:

```
  1) Failure:
TestGemCompiler#test_compile_bundle_artifacts [c:/src/gem-compiler/test/rubygems/test_gem_compiler.rb:109]: Expected ["C:/Users/Mike Bland/AppData/Local/Temp/d20160208-1672-1fuqr19/foo-1/lib/foo.so",
 "ext/foo/mkrf_conf.rb",
 "lib/foo.rb"] to include "lib/foo.so".
```

This change applies Dir.glob and File.join to `target_dir` to update the path components properly and fixes the test on Windows.

BTW, I tried running the tests on OS X 10.11.3, Ubuntu 14.04, and FreeBSD 10.2-p9, and all three reported errors such that rake-10.5.0 was missing, despite the fact that I did a `bundle install` and `bundle exec rake build`. I'm using rbenv, but even switching to the system Ruby on OS X (2.3.0 via Homebrew) didn't seem to help. Happy to open an issue with detailed output if desired.