### PR TITLE
Check Ruby and RubyGems version of gemspec

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 
 - Drop support for any Ruby version prior to 2.0.0
 - Workaround shortname directories on Windows. Thanks to @mbland (#17 & #19)
+- Validate both Ruby and RubyGems versions defined in gemspec
 
 ## 0.4.0 (2015-07-18)
 

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -91,6 +91,16 @@ class Gem::Compiler
       installer.spec.extension_dir = File.join(@target_dir, "lib")
     end
 
+    # Ensure Ruby version is met
+    if installer.respond_to?(:ensure_required_ruby_version_met)
+      installer.ensure_required_ruby_version_met
+    end
+
+    # Check version of RubyGems (just in case)
+    if installer.respond_to?(:ensure_required_rubygems_version_met)
+      installer.ensure_required_rubygems_version_met
+    end
+
     # Hmm, gem already compiled?
     if installer.spec.platform != Gem::Platform::RUBY
       raise CompilerError,

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -38,6 +38,35 @@ class TestGemCompiler < Gem::TestCase
     assert_equal "The gem file seems to be compiled already.", e.message
   end
 
+  def test_compile_required_ruby
+    gem_file = util_bake_gem("old_required") { |s| s.required_ruby_version = "= 1.4.6" }
+
+    compiler = Gem::Compiler.new(gem_file, :output => @output_dir)
+
+    e = assert_raises Gem::InstallError do
+      use_ui @ui do
+        compiler.compile
+      end
+    end
+
+    assert_equal "old_required requires Ruby version = 1.4.6.", e.message
+  end
+
+  def test_compile_required_rubygems
+    gem_file = util_bake_gem("old_rubygems") { |s| s.required_rubygems_version = "< 0" }
+
+    compiler = Gem::Compiler.new(gem_file, :output => @output_dir)
+
+    e = assert_raises Gem::InstallError do
+      use_ui @ui do
+        compiler.compile
+      end
+    end
+
+    assert_equal "old_rubygems requires RubyGems version < 0. " +
+      "Try 'gem update --system' to update RubyGems itself.", e.message
+  end
+
   def test_compile_succeed
     util_set_arch "i386-mingw32"
 


### PR DESCRIPTION
Before unpacking gem contents, check if both Ruby and RubyGems
versions (possible present in the gemspec) match the current ones.

This corrects the potential problem of attempt to compile a gem
that is not compatible with the current version of Ruby (or RubyGems)
that are installed.