### PR TITLE
Run RubyGems' pre_install hooks at compilation time

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 - Drop support for any Ruby version prior to 2.0.0
 - Workaround shortname directories on Windows. Thanks to @mbland (#17 & #19)
 - Validate both Ruby and RubyGems versions defined in gemspec
+- Ensure any RubyGems' `pre_install` hooks are run at extension compilation (#18)
 
 ## 0.4.0 (2015-07-18)
 

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -26,8 +26,7 @@ class Gem::Compiler
   def compile
     unpack
 
-    # build extensions
-    installer.build_extensions
+    build_extensions
 
     artifacts = collect_artifacts
 
@@ -58,6 +57,16 @@ class Gem::Compiler
       debug "Adding '#{file}' to gemspec"
       gemspec.files.push file
     end
+  end
+
+  def build_extensions
+    # run pre_install hooks
+
+    if installer.respond_to?(:run_pre_install_hooks)
+      installer.run_pre_install_hooks
+    end
+
+    installer.build_extensions
   end
 
   def cleanup

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -38,6 +38,31 @@ class TestGemCompiler < Gem::TestCase
     assert_equal "The gem file seems to be compiled already.", e.message
   end
 
+  def test_compile_pre_install_hooks
+    util_reset_arch
+
+    artifact = "foo.#{RbConfig::CONFIG["DLEXT"]}"
+
+    gem_file = util_bake_gem("foo") { |s|
+      util_fake_extension s, "foo", util_custom_configure(artifact)
+    }
+
+    hook_run = false
+
+    Gem.pre_install do |installer|
+      hook_run = true
+      true
+    end
+
+    compiler = Gem::Compiler.new(gem_file, :output => @output_dir)
+
+    use_ui @ui do
+      compiler.compile
+    end
+
+    assert hook_run, "pre_install hook not run"
+  end
+
   def test_compile_required_ruby
     gem_file = util_bake_gem("old_required") { |s| s.required_ruby_version = "= 1.4.6" }
 


### PR DESCRIPTION
Some tools like RubyInstaller's DevKit uses RubyGems' `pre_install`
hooks to alter the environment and prepend the compiler toolchain
for compilation of gem extensions.

With this change we aim to reduce documentation, friction and issues
when attempt to compile binary gems on Windows natively.

Closes #18