### PR TITLE
Lock Ruby's ABI on compiled gem

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,8 @@
 - Workaround shortname directories on Windows. Thanks to @mbland (#17 & #19)
 - Validate both Ruby and RubyGems versions defined in gemspec
 - Ensure any RubyGems' `pre_install` hooks are run at extension compilation (#18)
+- Lock compile gems to Ruby's ABI version which can be disabled using
+  `--no-abi-lock` option (#11)
 
 ## 0.4.0 (2015-07-18)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ process:
     Successfully installed nokogiri-1.6.6.2-x86_64-darwin-12
     1 gem installed
 
+#### Restrictions of binaries
+
+Gems compiled with `gem-compiler` will be lock to the version of Ruby used
+to compile them.
+
+This means that a gem compiled under Ruby 2.2 could only be installed under
+Ruby 2.2.
+
+You can disable this by using `--no-abi-lock` option during compilation:
+
+    $ gem compile yajl-ruby-1.1.0.gem --no-abi-lock
+
+**Warning**: this is not recommended since different versions of Ruby might
+expose different options on the API. The binary might be expecting specific
+features not present in the version of Ruby you're installing the binary gem
+into.
+
 ### Compiling from Rake
 
 Most of the times, as gem developer, you would like to generate both kind of

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -8,6 +8,10 @@ class Gem::Commands::CompileCommand < Gem::Command
     add_option "--prune", "Clean non-existing files during re-packaging" do |value, options|
       options[:prune] = true
     end
+
+    add_option "-N", "--no-abi-lock", "Do not lock compiled Gem to Ruby's ABI" do |value, options|
+      options[:no_abi_lock] = true
+    end
   end
 
   def arguments

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -132,6 +132,12 @@ class Gem::Compiler
     # adjust platform
     gemspec.platform = Gem::Platform::CURRENT
 
+    # adjust version of Ruby
+    unless @options[:no_abi_lock]
+      ruby_abi = RbConfig::CONFIG["ruby_version"]
+      gemspec.required_ruby_version = "~> #{ruby_abi}"
+    end
+
     # build new gem
     output_gem = nil
 


### PR DESCRIPTION
This ensures that resulting gem can only be installed on a compatible version of Ruby, reducing the chances of an incompatible option be exposed and the gem fail at runtime.

With this change is now the default behavior, which can be turned off by using `--no-abi-lock` option during compilation (but is discouraged).

Closes #11