### PR TITLE
Automatically release new gems when tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,21 @@ script:
   - bundle exec rake test
   - bundle exec rake package
   - gem install --local pkg/gem-compiler-*.gem
+deploy:
+  - provider: rubygems
+    api_key:
+      secure: GzcHK3D4/hNbU9BcpxqOR03I0bPqVdz4flz8UYX5wo6MmnmCqpqCyRvXJfBE62V47QFB8UUeMCtCQ1xWVHqZAxHCWIq9LwpVOxBMwcNjviF0sEuDyUiySlQzj2x0AFd9h1uLqRNVBH0AKs1jwB4wtcJF4baJxo3oMZH+Doxi44I=
+    gem: gem-compiler
+    on:
+      tags: true
+      repo: luislavena/gem-compiler
+      rvm: 2.1.9
+  - provider: releases
+    api_key:
+      secure: XahX146zzKPJHx7KlsI3pFNC201wuw3Az6+3eP62NdV6MVqjuazZ0XQZjUlemMSHhnpdk1MC7llqkwrl3Xvk2+WvpMMgvfnUNRP/ND+bjGfX/O/VjnG6PAjshGEI6UT+QfeIxglMVvYX7u1e4NWH3BzIUixoHulx6kRffuq+yz0=
+    file_glob: true
+    file: "pkg/gem-compiler-*.gem"
+    on:
+      tags: true
+      repo: luislavena/gem-compiler
+      rvm: 2.1.9

--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 
 - Drop support for any Ruby version prior to 2.1.0
 - Solve RubyGems 2.5 deprecation warnings
+- Use Travis to automate new releases
 
 ## 0.5.0 (2016-04-24)
 


### PR DESCRIPTION
Tagging releases will use Travis' deploy functionality to both upload artifacts of the build process (gem-compiler `.gem` file) to both RubyGems and GitHub releases page.
