### PR TITLE
Upgrade Travis and AppVeyor test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - ruby-head
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --version "~> 1.11" --no-ri --no-rdoc
+  - gem install bundler --version "~> 1.15.1" --no-ri --no-rdoc
   - bundle install --jobs=3 --retry=3
 
 test_script:
@@ -25,3 +25,5 @@ environment:
     - ruby_version: "22-x64"
     - ruby_version: "23"
     - ruby_version: "23-x64"
+    - ruby_version: "24"
+    - ruby_version: "24-x64"


### PR DESCRIPTION
- Include Ruby 2.4.1 on both Linux and Windows
- Update to latest 2.2 and 2.3 versions
- Use latest version of Bundler