### PR TITLE
Introduce `--output` option for compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ upgrading.
 
 ## [Unreleased]
 
+### Added
+- Introduce `--output` (`-O` in short) to specify the output directory where
+  compiled gem will be stored.
+
 ### Changed
 - Introduce `Makefile` for local development
 

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -5,6 +5,10 @@ class Gem::Commands::CompileCommand < Gem::Command
     super "compile", "Create binary pre-compiled gem",
           output: Dir.pwd
 
+    add_option "-O", "--output DIR", "Directory where binary will be stored" do |value, options|
+      options[:output] = File.expand_path(value, Dir.pwd)
+    end
+
     add_option "--prune", "Clean non-existing files during re-packaging" do |value, options|
       options[:prune] = true
     end


### PR DESCRIPTION
Allow user to supply a directory where compiled gem will be stored.

Keep existing default (current directory).