### PR TITLE
Use correct RubyGems exception on tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ upgrading.
 
 ## [Unreleased]
 
+### Fixed
+- Solve RubyGems 2.6.x changes on exception hierarchy. Thanks to @MSP-Greg (#30)
+
 ## [0.7.0] - 2017-10-01
 
 ### Added


### PR DESCRIPTION
Recent RubyGems changed exception hierarchy when requirements aren't
met. Instead of raising original `Gem::InstallError` it now raises
`Gem::RuntimeRequirementNotMetError` (more specific).

Adapt tests to workaround this and be backward compatible.

Fixes #30