### PR TITLE
CI: avoid hangs when installing Bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ upgrading.
 ### Fixed
 - Solve RubyGems 2.6.x changes on exception hierarchy. Thanks to @MSP-Greg (#30)
 
+### Changed
+- CI: Avoid possible issues when installing Bundler on AppVeyor
+
 ## [0.7.0] - 2017-10-01
 
 ### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --version "~> 1.15.1" --no-ri --no-rdoc
+  - gem install bundler --conservative --version "~> 1.15.4" --no-ri --no-rdoc
   - bundle install --jobs=3 --retry=3
 
 test_script:


### PR DESCRIPTION
Ruby 2.5.0 integrates Bundler with it, and with that, simple `gem install` might require user interaction.

Use `--conservative` to avoid forcing a install when potentially that gem is already installed.