### PR TITLE
Drop support for EOL Ruby and RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.5.0
   - 2.4.3
   - 2.3.6
-  - 2.2.9
-  - 2.1.10
   - ruby-head
 matrix:
   allow_failures:
@@ -26,7 +24,7 @@ deploy:
     on:
       tags: true
       repo: luislavena/gem-compiler
-      rvm: 2.1.10
+      rvm: 2.3.6
   - provider: releases
     api_key:
       secure: XahX146zzKPJHx7KlsI3pFNC201wuw3Az6+3eP62NdV6MVqjuazZ0XQZjUlemMSHhnpdk1MC7llqkwrl3Xvk2+WvpMMgvfnUNRP/ND+bjGfX/O/VjnG6PAjshGEI6UT+QfeIxglMVvYX7u1e4NWH3BzIUixoHulx6kRffuq+yz0=
@@ -35,4 +33,4 @@ deploy:
     on:
       tags: true
       repo: luislavena/gem-compiler
-      rvm: 2.1.10
+      rvm: 2.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ upgrading.
 ### Fixed
 - Solve RubyGems 2.6.x changes on exception hierarchy. Thanks to @MSP-Greg (#30)
 
+### Removed
+- Drop support for Ruby 2.1.x and 2.2.x, as they reached EOL (End Of Life)
+- Drop support for RubyGems older than 2.5.0
+
 ### Changed
 - CI: Avoid possible issues when installing Bundler on AppVeyor
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,3 @@ environment:
     - ruby_version: "24-x64"
     - ruby_version: "23"
     - ruby_version: "23-x64"
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
-    - ruby_version: "21"
-    - ruby_version: "21-x64"

--- a/gem-compiler.gemspec
+++ b/gem-compiler.gemspec
@@ -29,8 +29,8 @@ EOF
                    "lib/**/*.rb", "test/**/test*.rb"]
 
   # requirements
-  spec.required_ruby_version = ">= 2.1.0"
-  spec.required_rubygems_version = ">= 1.8.24"
+  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_rubygems_version = ">= 2.5.0"
 
   # development dependencies
   spec.add_development_dependency "rake", "~> 12.0", ">= 12.0.0"

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -2,12 +2,7 @@ require "fileutils"
 require "rbconfig"
 require "tmpdir"
 require "rubygems/installer"
-
-if Gem::VERSION >= "2.0.0"
-  require "rubygems/package"
-else
-  require "rubygems/builder"
-end
+require "rubygems/package"
 
 class Gem::Compiler
   include Gem::UserInteraction
@@ -149,11 +144,7 @@ class Gem::Compiler
     output_gem = nil
 
     Dir.chdir target_dir do
-      output_gem = if defined?(Gem::Builder)
-                     Gem::Builder.new(gemspec).build
-                   else
-                     Gem::Package.build(gemspec)
-                   end
+      output_gem = Gem::Package.build(gemspec)
     end
 
     unless output_gem


### PR DESCRIPTION
Ruby 2.1.x and 2.2.x have reached EOL (End Of Life) support. Removing those from our test matrix and ensure only supported versions of Ruby can be used to install this project.

Also bump minimum version of RubyGems required and remove workaround associated with old version.