### PR TITLE
Introduce `--include-shared-dir` to compile command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ upgrading.
 
 ## [Unreleased]
 
+### Added
+- Introduce `--include-shared-dir` to specify additional directory where to
+  lookup platform-specific shared libraries to bundle in the package. (#34)
+
 ### Fixed
 - Solve RubyGems 2.6.x changes on exception hierarchy. Thanks to @MSP-Greg (#30)
 

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -9,6 +9,10 @@ class Gem::Commands::CompileCommand < Gem::Command
       options[:output] = File.expand_path(value, Dir.pwd)
     end
 
+    add_option "--include-shared-dir DIR", "Additional directory for shared libraries" do |value, options|
+      options[:include_shared_dir] = value
+    end
+
     add_option "--prune", "Clean non-existing files during re-packaging" do |value, options|
       options[:prune] = true
     end

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -25,6 +25,12 @@ class Gem::Compiler
 
     artifacts = collect_artifacts
 
+    if shared_dir = options[:include_shared_dir]
+      shared_libs = collect_shared(shared_dir)
+
+      artifacts.concat shared_libs
+    end
+
     # build a new gemspec from the original one
     gemspec = installer.spec.dup
 
@@ -75,6 +81,12 @@ class Gem::Compiler
     Dir.glob("#{target_dir}/{#{lib_dirs}}/**/*.#{dlext}")
   end
 
+  def collect_shared(shared_dir)
+    libext = platform_shared_ext
+
+    Dir.glob("#{target_dir}/#{shared_dir}/**/*.#{libext}")
+  end
+
   def info(msg)
     say msg if Gem.configuration.verbose
   end
@@ -85,6 +97,21 @@ class Gem::Compiler
 
   def installer
     @installer ||= prepare_installer
+  end
+
+  def platform_shared_ext
+    platform = Gem::Platform.local
+
+    case platform.os
+    when /darwin/
+      "dylib"
+    when /linux|bsd|solaris/
+      "so"
+    when /mingw|mswin|cygwin|msys/
+      "dll"
+    else
+      "so"
+    end
   end
 
   def prepare_installer


### PR DESCRIPTION
Allow user to specify an additional directory to lookup for platform specific shared libraries with the objective to bundle those inside the final binary gem.

The directory is relative to the build location (ie. `ext` at the same level as `lib`).

Use this only on certain scenarios where a shared library is generated during gem installation (ie. FFI-powered one) but the artifact of such build is not relocated to the default require directory (`lib`).

Closes #34