### PR TITLE
add support for explicitly specifying some artifacts to add

### DIFF
--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -13,6 +13,10 @@ class Gem::Commands::CompileCommand < Gem::Command
       options[:include_shared_dir] = value
     end
 
+    add_option "--artifact PATH", "Additional artifact to package (relative to the gem dir)" do |value, options|
+      (options[:artifacts] ||= []) << value
+    end
+
     add_option "--prune", "Clean non-existing files during re-packaging" do |value, options|
       options[:prune] = true
     end


### PR DESCRIPTION
The 'rice' gem has bunch of files in ruby/lib that is not part
of the gem proper - it is to be used by the libraries. It's
obviously a misuse of the Rubygems system, but a useful one
so far.

This adds the --artifact PATH argument that allows to:
- add a file explicitly
- add a complete directory tree