### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - 2.7.0
   - 2.6.5
   - 2.5.7
   - 2.4.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ upgrading.
 
 ## [Unreleased]
 
+### Fixed
+- Solve upcoming RubyGems deprecation warnings
+
 ### Changed
 - Deal with RubyGems 3.x `new_spec` deprecation in tests.
 

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -197,6 +197,14 @@ class Gem::Compiler
     # unpack gem sources into target_dir
     # We need the basename to keep the unpack happy
     info "Unpacking gem: '#{basename}' in temporary directory..."
-    installer.unpack(@target_dir)
+
+    # RubyGems >= 3.1.x
+    if installer.respond_to?(:package)
+      package = installer.package
+    else
+      package = Gem::Package.new(@gemfile)
+    end
+
+    package.extract_files(@target_dir)
   end
 end


### PR DESCRIPTION
Include Ruby 2.7 in the CI matrix.

Also fix deprecation warnings shown in this and `ruby-head` associated with RubyGems' `Gem::Installer#unpack` impending removal.