### PR TITLE
Drop support for RubyGems older than 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ upgrading.
 
 ### Removed
 - Drop support for Ruby 2.3.x, as it reached EOL (End Of Life)
+- Drop support for RubyGems older than 2.6.0 (Ruby 2.4 includes RubyGems 2.6.8)
 
 ## [0.8.0] - 2017-12-28
 

--- a/gem-compiler.gemspec
+++ b/gem-compiler.gemspec
@@ -30,7 +30,7 @@ EOF
 
   # requirements
   spec.required_ruby_version = ">= 2.4.0"
-  spec.required_rubygems_version = ">= 2.5.0"
+  spec.required_rubygems_version = ">= 2.6.0"
 
   # development dependencies
   spec.add_development_dependency "rake", "~> 12.0", ">= 12.0.0"

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -115,19 +115,9 @@ class Gem::Compiler
   end
 
   def prepare_installer
-    # RubyGems 2.5 specifics
-    unpack_options = options.dup.merge(unpack: true)
-    if Gem::Installer.respond_to?(:at)
-      installer = Gem::Installer.at(@gemfile, unpack_options)
-    else
-      installer = Gem::Installer.new(@gemfile, options.dup.merge(unpack: true))
-    end
-
-    # RubyGems 2.2 specifics
-    if installer.spec.respond_to?(:full_gem_path=)
-      installer.spec.full_gem_path = @target_dir
-      installer.spec.extension_dir = File.join(@target_dir, "lib")
-    end
+    installer = Gem::Installer.at(@gemfile, options.dup.merge(unpack: true))
+    installer.spec.full_gem_path = @target_dir
+    installer.spec.extension_dir = File.join(@target_dir, "lib")
 
     # Ensure Ruby version is met
     if installer.respond_to?(:ensure_required_ruby_version_met)


### PR DESCRIPTION
Oldest supported version of Ruby (2.4.0) ships with RubyGems 2.6.8
and all the newer X.Y.0 versions ships with updates too:

- Ruby 2.4.0: RubyGems 2.6.8
- Ruby 2.4.9: RubyGems 2.6.14.4
- Ruby 2.5.0: RubyGems 2.7.3
- Ruby 2.5.7: RubyGems 2.7.6.2
- Ruby 2.6.0: RubyGems 3.0.1
- Ruby 2.6.5: RubyGems 3.0.3
- Ruby 2.7.0: RubyGems 3.1.2