### PR TITLE
Perform noop trying to compile non-compilable gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ upgrading.
 ### Changed
 - Deal with RubyGems 3.x `new_spec` deprecation in tests.
 - CI: Replace Travis/AppVeyor with GitHub Actions for Ubuntu, macOS and Windows.
+- No longer raise exceptions when executed against non-compilable gems. (#38)
 
 ### Removed
 - Drop support for Ruby 2.3.x, as it reached EOL (End Of Life)

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -131,14 +131,16 @@ class Gem::Compiler
 
     # Hmm, gem already compiled?
     if installer.spec.platform != Gem::Platform::RUBY
-      raise CompilerError,
-            "The gem file seems to be compiled already."
+      info "The gem file seems to be compiled already. Done."
+      cleanup
+      terminate_interaction
     end
 
     # Hmm, no extensions?
     if installer.spec.extensions.empty?
-      raise CompilerError,
-            "There are no extensions to build on this gem file."
+      info "There are no extensions to build on this gem file. Done."
+      cleanup
+      terminate_interaction
     end
 
     installer

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -25,14 +25,16 @@ class TestGemCompiler < Gem::TestCase
 
     compiler = Gem::Compiler.new(gem_file, :output => @output_dir)
 
-    e = assert_raises Gem::Compiler::CompilerError do
+    assert_raises Gem::MockGemUi::SystemExitException do
       use_ui @ui do
         compiler.compile
       end
     end
 
-    assert_equal "There are no extensions to build on this gem file.",
-                 e.message
+    out = @ui.output.split "\n"
+
+    assert_equal "There are no extensions to build on this gem file. Done.",
+                  out.last
   end
 
   def test_compile_non_ruby
@@ -40,13 +42,15 @@ class TestGemCompiler < Gem::TestCase
 
     compiler = Gem::Compiler.new(gem_file, :output => @output_dir)
 
-    e = assert_raises Gem::Compiler::CompilerError do
+    assert_raises Gem::MockGemUi::SystemExitException do
       use_ui @ui do
         compiler.compile
       end
     end
 
-    assert_equal "The gem file seems to be compiled already.", e.message
+    out = @ui.output.split "\n"
+
+    assert_equal "The gem file seems to be compiled already. Done.", out.last
   end
 
   def test_compile_pre_install_hooks


### PR DESCRIPTION
No longer raise exceptions when executed against gems already pre-compiled or gems that have no extensions.

This aims to ease simple automation scenarios.

```console
$ gem compile addressable-2.7.0.gem
Unpacking gem: 'addressable-2.7.0' in temporary directory...
There are no extensions to build on this gem file. Done.

$ gem compile unf_ext-0.0.7.6-x86_64-linux.gem
Unpacking gem: 'unf_ext-0.0.7.6-x86_64-linux' in temporary directory...
The gem file seems to be compiled already. Done.
```

In both cases, exit code is zero (0).

Fixes #38