### PR TITLE
Allow optional stripping of compiled extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ upgrading.
 
 ## [Unreleased]
 
+### Added
+- Allow symbol stripping from extensions (using `--strip` and/or `--strip-cmd`). (#40)
+
 ### Fixed
 - Solve upcoming RubyGems deprecation warnings
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,38 @@ expose different options on the API. The binary might be expecting specific
 features not present in the version of Ruby you're installing the binary gem
 into.
 
+#### Reducing extension's size (stripping)
+
+By default, RubyGems do not strip symbols from compiled extensions, including
+debugging information and can result in increased size of final package.
+
+With `--strip`, you can reduce extensions by using same stripping options used
+by Ruby itself (see `RbConfig::CONFIG["STRIP"]`):
+
+```console
+$ gem compile oj-3.10.0.gem --strip
+Unpacking gem: 'oj-3.10.0' in temporary directory...
+Building native extensions. This could take a while...
+Stripping symbols from extensions (using 'strip -S -x')...
+  Successfully built RubyGem
+  Name: oj
+  Version: 3.10.0
+  File: oj-3.10.0-x86_64-linux.gem
+```
+
+Or you can provide your own stripping command instead using `--strip-cmd`:
+
+```console
+$ gem compile oj-3.10.0.gem --strip-cmd "strip --strip-unneeded"
+Unpacking gem: 'oj-3.10.0' in temporary directory...
+Building native extensions. This could take a while...
+Stripping symbols from extensions (using 'strip --strip-unneeded')...
+  Successfully built RubyGem
+  Name: oj
+  Version: 3.10.0
+  File: oj-3.10.0-x86_64-linux.gem
+```
+
 ### Compiling from Rake
 
 Most of the times, as gem developer, you would like to generate both kind of

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -20,6 +20,15 @@ class Gem::Commands::CompileCommand < Gem::Command
     add_option "-N", "--no-abi-lock", "Do not lock compiled Gem to Ruby's ABI" do |value, options|
       options[:no_abi_lock] = true
     end
+
+    add_option "-S", "--strip", "Strip symbols from generated binaries" do |value, options|
+      options[:strip] = true
+    end
+
+    add_option "--strip-cmd CMD", "Strip command with args to use (implies --strip)" do |value, options|
+      options[:strip] = true
+      options[:strip_cmd] = value
+    end
   end
 
   def arguments


### PR DESCRIPTION
Introduce `--strip` to perform stripping on compiled extensions (using same command as defined by `RbConfig::CONFIG["STRIP"]`).

Or using a custom stripping command using `--strip-cmd`, allowing different executable and flags to be used.

Examples:

```console
$ gem compile oj-3.10.0.gem --strip
Unpacking gem: 'oj-3.10.0' in temporary directory...
Building native extensions. This could take a while...
Stripping symbols from extensions (using 'strip -S -x')...
  Successfully built RubyGem
  Name: oj
  Version: 3.10.0
  File: oj-3.10.0-x86_64-linux.gem
```

```console
$ gem compile oj-3.10.0.gem --strip-cmd "strip --strip-unneeded"
Unpacking gem: 'oj-3.10.0' in temporary directory...
Building native extensions. This could take a while...
Stripping symbols from extensions (using 'strip --strip-unneeded')...
  Successfully built RubyGem
  Name: oj
  Version: 3.10.0
  File: oj-3.10.0-x86_64-linux.gem
```

This is not enabled by default.

Closes #40.