### PR TITLE
Ensure proper support for frozen string literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems/package_task"
 
 gemspec = Gem::Specification.load("gem-compiler.gemspec")

--- a/gem-compiler.gemspec
+++ b/gem-compiler.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems/command"
 
 class Gem::Commands::CompileCommand < Gem::Command

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "open3"
 require "rbconfig"

--- a/lib/rubygems/compiler/version.rb
+++ b/lib/rubygems/compiler/version.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 
 module Gem
   class Compiler

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "rubygems/command_manager"
 Gem::CommandManager.instance.register_command :compile

--- a/test/rubygems/test_gem_commands_compile_command.rb
+++ b/test/rubygems/test_gem_commands_compile_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems/test_case"
 require "rubygems/commands/compile_command"
 require "rubygems/package"

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems/test_case"
 require "rubygems/compiler"
 


### PR DESCRIPTION
Use Ruby's magic comment to ensure all Ruby files within this project work correctly with this setting on.