### PR TITLE
Expand and normalize ABI lock mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ upgrading.
 
 ### Added
 - Allow symbol stripping from extensions (using `--strip`). (#40)
+- Introduce more strict Ruby version locking (using `--abi-lock`). (#51)
 
 ### Fixed
 - Solve upcoming RubyGems deprecation warnings

--- a/README.md
+++ b/README.md
@@ -130,22 +130,27 @@ process:
     Successfully installed nokogiri-1.6.6.2-x86_64-darwin-12
     1 gem installed
 
-#### Restrictions of binaries
+#### Restricting generated binary gems
 
-Gems compiled with `gem-compiler` will be lock to the version of Ruby used
-to compile them.
+Gems compiled with `gem-compiler` be lock to the version of Ruby used
+to compile them, following Ruby's ABI compatibility (`MAJOR.MINOR`)
 
-This means that a gem compiled under Ruby 2.2 could only be installed under
-Ruby 2.2.
+This means that a gem compiled with Ruby 2.6.1 could be installed in any
+version of Ruby 2.6.x (Eg. 2.6.4).
 
-You can disable this by using `--no-abi-lock` option during compilation:
+You can tweak this behavior by using `--abi-lock` option during compilation.
+There are 3 available modes:
 
-    $ gem compile yajl-ruby-1.1.0.gem --no-abi-lock
+* `ruby`: Follows Ruby's ABI. Gems compiled with Ruby 2.6.1 can be installed
+  in any Ruby 2.6.x (default behavior).
+* `strict`: Uses Ruby's full version. Gems compiled with Ruby 2.6.1 can only
+  be installed in Ruby 2.6.1.
+* `none`: Disables Ruby compatibility. Gems compiled with this option can be
+  installed on any version of Ruby (alias for `--no-abi-lock`).
 
-**Warning**: this is not recommended since different versions of Ruby might
-expose different options on the API. The binary might be expecting specific
-features not present in the version of Ruby you're installing the binary gem
-into.
+**Warning**: usage of `none` is not recommended since different versions of
+Ruby might expose different APIs. The binary might be expecting specific
+features not present in the version of Ruby you're installing the gem into.
 
 #### Reducing extension's size (stripping)
 

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -49,6 +49,19 @@ class Gem::Compiler
 
   private
 
+  def adjust_abi_lock(gemspec)
+    abi_lock = @options[:abi_lock] || :ruby
+    case abi_lock
+    when :ruby
+      ruby_abi = RbConfig::CONFIG["ruby_version"]
+      gemspec.required_ruby_version = "~> #{ruby_abi}"
+    when :strict
+      cfg = RbConfig::CONFIG
+      ruby_abi = "#{cfg["MAJOR"]}.#{cfg["MINOR"]}.#{cfg["TEENY"]}.0"
+      gemspec.required_ruby_version = "~> #{ruby_abi}"
+    end
+  end
+
   def adjust_gemspec_files(gemspec, artifacts)
     # remove any non-existing files
     if @options[:prune]
@@ -159,10 +172,7 @@ class Gem::Compiler
     gemspec.platform = Gem::Platform::CURRENT
 
     # adjust version of Ruby
-    unless @options[:no_abi_lock]
-      ruby_abi = RbConfig::CONFIG["ruby_version"]
-      gemspec.required_ruby_version = "~> #{ruby_abi}"
-    end
+    adjust_abi_lock(gemspec)
 
     # build new gem
     output_gem = nil

--- a/test/rubygems/test_gem_commands_compile_command.rb
+++ b/test/rubygems/test_gem_commands_compile_command.rb
@@ -23,6 +23,45 @@ class TestGemCommandsCompileCommand < Gem::TestCase
     assert_match %r{Please specify a gem file on the command line}, e.message
   end
 
+  def test_handle_abi_lock_ruby
+    @cmd.handle_options []
+
+    assert_equal :ruby, @cmd.options[:abi_lock]
+  end
+
+  def test_handle_abi_lock_explicit_ruby
+    @cmd.handle_options ["--abi-lock=ruby"]
+
+    assert_equal :ruby, @cmd.options[:abi_lock]
+  end
+
+  def test_handle_abi_lock_strict
+    @cmd.handle_options ["--abi-lock=strict"]
+
+    assert_equal :strict, @cmd.options[:abi_lock]
+  end
+
+  def test_handle_abi_lock_none
+    @cmd.handle_options ["--abi-lock=none"]
+
+    assert_equal :none, @cmd.options[:abi_lock]
+  end
+
+  def test_handle_no_abi_lock_none
+    @cmd.handle_options ["--no-abi-lock"]
+
+    assert_equal :none, @cmd.options[:abi_lock]
+  end
+
+  def test_handle_abi_lock_unknown
+    e = assert_raises OptionParser::InvalidArgument do
+      @cmd.handle_options %w[--abi-lock unknown]
+    end
+
+    assert_equal "invalid argument: --abi-lock unknown (none, ruby, strict are valid)",
+                 e.message
+  end
+
   def test_handle_strip_default
     @cmd.handle_options %w[--strip]
 

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -332,7 +332,7 @@ class TestGemCompiler < Gem::TestCase
 
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal spec.required_ruby_version, Gem::Requirement.new("~> #{ruby_abi}")
+    assert_equal Gem::Requirement.new("~> #{ruby_abi}"), spec.required_ruby_version
   end
 
   def test_compile_no_lock_ruby_abi
@@ -353,7 +353,7 @@ class TestGemCompiler < Gem::TestCase
 
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal spec.required_ruby_version, Gem::Requirement.new(">= 0")
+    assert_equal Gem::Requirement.new(">= 0"), spec.required_ruby_version
   end
 
   def test_compile_strip_cmd


### PR DESCRIPTION
Allow more strict locking of compiled gems to help scenarios where portability becomes an issue due location of installed Ruby.

For example RVM uses all 3 parts of Ruby version (X.Y.Z) to construct the installation directory where `libruby.so` is installed: `/usr/local/rvm/rubies/ruby-2.6.5/lib/libruby.so.2.6`, which causes
issues with gems compiled with a different version as LD is unable to find the right path for those shared libraries.

Using `--abi-lock=strict` option, will make sure that compiled gem is only installable in that specific version of Ruby `MAJOR.MINOR.TEENY` instead of default's Ruby ABI mode `MAJOR.MINOR`.

With this new mode, opted to normalize the available options to provide a bit more clarity on the usage of `--abi-lock` and `--no-abi-lock`.

Options for `--abi-lock`:

* `ruby`: Follows Ruby's ABI. Gems compiled with Ruby 2.6.1 can be installed in any Ruby 2.6.x (this is default behavior)
* `strict`: Uses Ruby's full version. Gems compiled with Ruby 2.6.1 can only be installed in Ruby 2.6.1
* `none`: Disables Ruby compatibility entirely. Gems compiled with this option can be installed on any version of Ruby.

Usage of `--no-abi-lock` is the same as `--abi-lock=none`.

Closes #51