### PR TITLE
add an extension version number

### DIFF
--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -30,6 +30,10 @@ class Gem::Commands::CompileCommand < Gem::Command
       options[:prune] = true
     end
 
+    add_option "--ext-version-number NUMBER", "Add an extension number at the end of the gem version" do |value, options|
+      options[:ext_version_number] = value
+    end
+
     add_option "--abi-lock MODE",
       "Lock to version of Ruby (ruby, strict, none)" do |value, options|
 

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -43,7 +43,7 @@ class Gem::Compiler
 
     if ext_version_number = options[:ext_version_number]
       if ext_version_number.to_i > 0
-        gemspec.version += '.' + ext_version_number
+        gemspec.version += '.' + ext_version_number.to_s
       else
         info "The extension version number is not a positive number. Skipping."
         cleanup

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -43,7 +43,7 @@ class Gem::Compiler
 
     if ext_version_number = options[:ext_version_number]
       if ext_version_number.to_i > 0
-        gemspec.version += '.' + ext_version_number.to_s
+        gemspec.version = Gem::Version.create("#{gemspec.version.to_s}.#{ext_version_number.to_s}")
       else
         info "The extension version number is not a positive number. Skipping."
         cleanup

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -41,6 +41,16 @@ class Gem::Compiler
 
     adjust_gemspec_files gemspec, artifacts
 
+    if ext_version_number = options[:ext_version_number]
+      if ext_version_number.to_i > 0
+        gemspec.version += '.' + ext_version_number.to_i
+      else
+        info "The extension version number is not a positive number. Skipping."
+        cleanup
+        terminate_interaction
+      end
+    end
+
     # generate new gem and return new path to it
     repackage gemspec
   ensure

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -43,7 +43,7 @@ class Gem::Compiler
 
     if ext_version_number = options[:ext_version_number]
       if ext_version_number.to_i > 0
-        gemspec.version += '.' + ext_version_number.to_i
+        gemspec.version += '.' + ext_version_number
       else
         info "The extension version number is not a positive number. Skipping."
         cleanup

--- a/test/rubygems/test_gem_commands_compile_command.rb
+++ b/test/rubygems/test_gem_commands_compile_command.rb
@@ -62,6 +62,12 @@ class TestGemCommandsCompileCommand < Gem::TestCase
                  e.message
   end
 
+  def test_handle_ext_version_number
+    @cmd.handle_options ["--ext-version-number=1"]
+
+    assert_equal :none, @cmd.options[:ext_version_number]
+  end
+
   def test_handle_strip_default
     @cmd.handle_options %w[--strip]
 

--- a/test/rubygems/test_gem_commands_compile_command.rb
+++ b/test/rubygems/test_gem_commands_compile_command.rb
@@ -65,7 +65,7 @@ class TestGemCommandsCompileCommand < Gem::TestCase
   def test_handle_ext_version_number
     @cmd.handle_options ["--ext-version-number=1"]
 
-    assert_equal :none, @cmd.options[:ext_version_number]
+    assert_equal "1", @cmd.options[:ext_version_number]
   end
 
   def test_handle_strip_default

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -441,7 +441,7 @@ class TestGemCompiler < Gem::TestCase
     previous_spec = util_read_spec gem_file
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal Gem::Requirement.new(previous_spec.version + '.1'), spec.version
+    assert_equal Gem::Requirement.new(previous_spec.version.to_s + '.1'), spec.version.to_s
   end
 
   def test_compile_strip_cmd

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -441,7 +441,7 @@ class TestGemCompiler < Gem::TestCase
     previous_spec = util_read_spec gem_file
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal Gem::Requirement.new(previous_spec.version.to_s + '.1'), spec.version.to_s
+    assert_equal previous_spec.version.to_s + '.1', spec.version.to_s
   end
 
   def test_compile_strip_cmd

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -410,10 +410,11 @@ class TestGemCompiler < Gem::TestCase
     }
 
     compiler = Gem::Compiler.new(gem_file, :output => @output_dir, :ext_version_number => 'a')
-    output_gem = nil
 
-    use_ui @ui do
-      output_gem = compiler.compile
+    assert_raises Gem::MockGemUi::SystemExitException do
+      use_ui @ui do
+        compiler.compile
+      end
     end
 
     out = @ui.output.split "\n"
@@ -438,10 +439,9 @@ class TestGemCompiler < Gem::TestCase
       output_gem = compiler.compile
     end
 
-    previous_spec = util_read_spec gem_file
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal previous_spec.version.to_s + '.1', spec.version.to_s
+    assert_equal Gem::Requirement.new("1.1"), spec.version
   end
 
   def test_compile_strip_cmd

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -441,7 +441,7 @@ class TestGemCompiler < Gem::TestCase
 
     spec = util_read_spec File.join(@output_dir, output_gem)
 
-    assert_equal Gem::Requirement.new("1.1"), spec.version
+    assert_equal Gem::Version.new("1.1"), spec.version
   end
 
   def test_compile_strip_cmd


### PR DESCRIPTION
The extension version number provides a way to compile different gems from the same upstream gem without conflict.

For instance, it can be used to push a puma with SSL and a puma without SSL in the same gemstash server.