### PR TITLE
Fix tests and update code usage for newer Ruby

### DIFF
--- a/gem-compiler.gemspec
+++ b/gem-compiler.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |spec|
 
   # description
   spec.summary = "A RubyGems plugin that generates binary gems."
-  spec.description = <<-EOF
-A RubyGems plugin that helps generates binary gems from already existing
-ones without altering the original source code. It compiles Ruby C
-extensions and bundles the result into a new gem.
-EOF
+  spec.description = <<~EOF
+    A RubyGems plugin that helps generates binary gems from already existing
+    ones without altering the original source code. It compiles Ruby C
+    extensions and bundles the result into a new gem.
+  EOF
 
   # project info
   spec.homepage = "https://github.com/luislavena/gem-compiler"

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -554,9 +554,10 @@ class TestGemCompiler < Gem::TestCase
     <<-EO_MKRF
       File.open("Rakefile", "w") do |f|
         f.puts <<-EOF
+          require 'fileutils'
           task :default do
             lib_dir = ENV["RUBYARCHDIR"] || ENV["RUBYLIBDIR"]
-            touch File.join(lib_dir, #{target.inspect})
+            FileUtils.touch File.join(lib_dir, #{target.inspect})
           end
         EOF
       end

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -256,7 +256,7 @@ class TestGemCompiler < Gem::TestCase
 
         FileUtils.touch "#{artifact}"
 
-        File.open 'Rakefile', 'w' do |rf| rf.puts "task :default" end
+        File.write('Rakefile', "task :default")
       EOF
     }
 
@@ -292,7 +292,7 @@ class TestGemCompiler < Gem::TestCase
 
         FileUtils.touch "#{artifact}"
 
-        File.open 'Rakefile', 'w' do |rf| rf.puts "task :default" end
+        File.write('Rakefile', "task :default")
       EOF
     }
 

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -137,7 +137,7 @@ class TestGemCompiler < Gem::TestCase
 
     gem_file = util_bake_gem(name, 'ports/to_be_deleted_during_ext_build.patch') { |spec|
       old_spec = spec
-      util_fake_extension spec, name, <<-EOF
+      util_fake_extension spec, name, <<~EOF
         require 'fileutils'
         FileUtils.rm File.expand_path(File.join(File.dirname(__FILE__), '../../ports/to_be_deleted_during_ext_build.patch'))
         #{util_custom_configure(artifact)}
@@ -251,7 +251,7 @@ class TestGemCompiler < Gem::TestCase
 
     gem_file = util_bake_gem(name) { |spec|
       old_spec = spec
-      util_fake_extension spec, name, <<-EOF
+      util_fake_extension spec, name, <<~EOF
         require "fileutils"
 
         FileUtils.touch "#{artifact}"
@@ -287,7 +287,7 @@ class TestGemCompiler < Gem::TestCase
 
     gem_file = util_bake_gem(name) { |spec|
       old_spec = spec
-      util_fake_extension spec, name, <<-EOF
+      util_fake_extension spec, name, <<~EOF
         require "fileutils"
 
         FileUtils.touch "#{artifact}"
@@ -536,8 +536,8 @@ class TestGemCompiler < Gem::TestCase
         if script
           f.write script
         else
-          f.write <<-EOF
-            File.open 'Rakefile', 'w' do |rf| rf.puts "task :default" end
+          f.write <<~EOF
+            File.write('Rakefile', "task :default")
           EOF
         end
       end
@@ -551,9 +551,9 @@ class TestGemCompiler < Gem::TestCase
   # Provided +target+ will be used to fake an empty file at default task
 
   def util_custom_configure(target)
-    <<-EO_MKRF
+    <<~EO_MKRF
       File.open("Rakefile", "w") do |f|
-        f.puts <<-EOF
+        f.puts <<~EOF
           require 'fileutils'
           task :default do
             lib_dir = ENV["RUBYARCHDIR"] || ENV["RUBYLIBDIR"]


### PR DESCRIPTION
1. Use squiggly heredocs introduced in Ruby 2.3 (ages ago)
2. Make sure that tests can be run within bundled version of Rake (`bundle exec rake test` or using binstub)