### PR TITLE
Allow adding build number to compiled gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,30 @@ Stripping symbols from extensions (using 'strip --strip-unneeded')...
   File: oj-3.10.0-x86_64-linux.gem
 ```
 
+### Append build number to gem version
+
+Gem servers like RubyGems or Gemstash treat gems as immutable, so once a gem
+has been pushed, you cannot replace it.
+
+When playing with compilation options or library dependencies, you might
+require to build and push an updated version of the same version.
+
+You can use `--build-number` to add the build number to the compiled version
+and push an updated build, maintaining gem dependency compatibility:
+
+```console
+$ gem compile oj-3.11.3.gem --build-number 10
+Unpacking gem: 'oj-3.11.3' in temporary directory...
+Building native extensions. This could take a while...
+  Successfully built RubyGem
+  Name: oj
+  Version: 3.11.3.10
+  File: oj-3.11.3.10-x86_64-linux.gem
+```
+
+This new version remains compatible with RubyGems' dependency requirements
+like `~> 3.11` or `~> 3.11.3`.
+
 ### Compiling from Rake
 
 Most of the times, as gem developer, you would like to generate both kind of

--- a/lib/rubygems/commands/compile_command.rb
+++ b/lib/rubygems/commands/compile_command.rb
@@ -53,6 +53,16 @@ class Gem::Commands::CompileCommand < Gem::Command
         options[:strip] = value
       end
     end
+
+    add_option "--build-number NUMBER",
+      "Append build number to compiled Gem version" do |value, options|
+
+      begin
+        options[:build_number] = Integer(value).abs
+      rescue ArgumentError
+        raise OptionParser::InvalidArgument, "must be a number"
+      end
+    end
   end
 
   def arguments

--- a/lib/rubygems/compiler.rb
+++ b/lib/rubygems/compiler.rb
@@ -188,6 +188,11 @@ class Gem::Compiler
     # adjust platform
     gemspec.platform = Gem::Platform::CURRENT
 
+    # adjust gem version
+    if build_number = options[:build_number]
+      gemspec.version = Gem::Version.create("#{gemspec.version}.#{build_number}")
+    end
+
     # adjust version of Ruby
     adjust_abi_lock(gemspec)
 

--- a/test/rubygems/test_gem_commands_compile_command.rb
+++ b/test/rubygems/test_gem_commands_compile_command.rb
@@ -73,4 +73,19 @@ class TestGemCommandsCompileCommand < Gem::TestCase
 
     assert_equal "strip --custom", @cmd.options[:strip]
   end
+
+  def test_handle_build_number
+    @cmd.handle_options %w[--build-number 10]
+
+    assert_equal 10, @cmd.options[:build_number]
+  end
+
+  def test_handle_invalid_build_number
+    e = assert_raises OptionParser::InvalidArgument do
+      @cmd.handle_options %w[--build-number a]
+    end
+
+    assert_equal "invalid argument: --build-number must be a number",
+                  e.message
+  end
 end

--- a/test/rubygems/test_gem_compiler.rb
+++ b/test/rubygems/test_gem_compiler.rb
@@ -398,6 +398,27 @@ class TestGemCompiler < Gem::TestCase
     assert_equal Gem::Requirement.new(">= 0"), spec.required_ruby_version
   end
 
+  def test_compile_build_number
+    util_reset_arch
+
+    artifact = "bar.#{RbConfig::CONFIG["DLEXT"]}"
+
+    gem_file = util_bake_gem("bar") { |s|
+      util_fake_extension s, "bar", util_custom_configure(artifact)
+    }
+
+    compiler = Gem::Compiler.new(gem_file, output: @output_dir, build_number: 50)
+    output_gem = nil
+
+    use_ui @ui do
+      output_gem = compiler.compile
+    end
+
+    spec = util_read_spec File.join(@output_dir, output_gem)
+
+    assert_equal Gem::Version.create("1.50"), spec.version
+  end
+
   def test_compile_strip_cmd
     util_reset_arch
     hook_simple_run


### PR DESCRIPTION
Introduce an optional `--build-number` compile option to increase the compiled gem version from the original one.

This is useful since local compilation might be trial and error about compilation options and gems pushed to RubyGems or Gemstash are immutable and cannot be replaced.

With this change, you can append this build number to the version and remain compatible with any existing gem requirement like `~> X.Y` or `~> X.Y.Z`.

Imagine compiling `nokogiri` `1.11.3` using system libraries:

```console
$ gem compile nokogiri-1.11.3.gem --prune -- --use-system-libraries
...
```

Then, realizing that your OS system libraries are vulnerable to a reported CVE, you can build and push a compatible `1.11.3` version that uses the bundled dependencies instead:

```console
$ gem compile nokogiri-1.11.3.gem --prune --build-number 1
Unpacking gem: 'nokogiri-1.11.3' in temporary directory...
Building native extensions. This could take a while...
...
    Successfully built RubyGem
    Name: nokogiri
    Version: 1.11.3.1
    File: nokogiri-1.11.3.1-x86_64-linux.gem
```

This new version `1.11.3.1` will satisfy most of pessimistic dependency constraints:

```ruby
v1 = Gem::Version.create("1.11.3")
# => #<Gem::Version "1.11.3">

v2 = Gem::Version.create("1.11.3.1")
# => #<Gem::Version "1.11.3.1">

r1 = Gem::Requirement.create("~> 1.11.3")
r2 = Gem::Requirement.create("~> 1.11")

r1.satisfied_by? v1
# => true

r1.satisfied_by? v2
# => true

r2.satisfied_by? v1
# => true

r2.satisfied_by? v2
# => true
```

Giving you build flexibility and remain compatible.

Closes #57
Closes #59